### PR TITLE
TLP support in feed/documents/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Scio uses [tika](https://tika.apache.org) to extract text from documents (PDF, H
 The result is sent to the Scio Analyzer that extracts information using a combination of NLP
 (Natural Language Processing) and pattern matching.
 
+## Changelog
+
+### 0.0.42
+
+SCIO now supports setting TLP on data upload, to annotatet documents with `tlp` tag. Documents downloaded by feeds will have a default TLP white, but this can be changed in the config for feeds.
+
 ## Source code
 
 The source code the workers are available on [github](https://github.com/mnemonic-no/act-scio2).

--- a/act/scio/api.py
+++ b/act/scio/api.py
@@ -35,9 +35,11 @@ from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi.responses import FileResponse, PlainTextResponse
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic.types import constr
+from pydantic.typing import Literal
 
 import act.scio.config
 import act.scio.es
+from act.scio import tlp
 
 XDG_CACHE = os.path.expanduser(os.environ.get("XDG_CACHE_HOME", "~/.cache"))
 
@@ -69,6 +71,7 @@ class Document(BaseModel):
     content: StrictStr
     filename: StrictStr
     uri: Optional[StrictStr]
+    tlp: Optional[tlp.TLP]
 
 
 class LookupResponse(BaseModel):
@@ -85,6 +88,7 @@ class SubmitResponse(BaseModel):
     hexdigest: StrictStr
     count: StrictInt
     uri: Optional[StrictStr]
+    tlp: Optional[tlp.TLP]
     error: Optional[StrictStr]
 
 
@@ -178,6 +182,7 @@ async def submit(
         filename=filename,
         hexdigest=hashlib.sha256(content).hexdigest(),
         count=len(content),
+        tlp=doc.tlp,
         error=None,
         uri=doc.uri,
     )

--- a/act/scio/etc/scio.ini
+++ b/act/scio/etc/scio.ini
@@ -42,7 +42,7 @@
 
 [feeds]
 # log =
-# tlp=
+# tlp=WHITE
 # file-format = pdf doc xls csv xml
 # store-path = ~/.cache/scio-feeds
 # feeds = ~/.config/scio/etc/feeds.txt

--- a/act/scio/etc/scio.ini
+++ b/act/scio/etc/scio.ini
@@ -42,6 +42,7 @@
 
 [feeds]
 # log =
+# tlp=
 # file-format = pdf doc xls csv xml
 # store-path = ~/.cache/scio-feeds
 # feeds = ~/.config/scio/etc/feeds.txt

--- a/act/scio/feeds/conf.py
+++ b/act/scio/feeds/conf.py
@@ -41,7 +41,8 @@ def get_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--tlp",
-        help="Set TLP (RED, AMBER, GREEN, WHITE) on document upload",
+        help="Set TLP (RED, AMBER, GREEN, WHITE) on document upload. Default=WHITE",
+        default="WHITE",
     )
     parser.add_argument(
         "--scio",

--- a/act/scio/feeds/conf.py
+++ b/act/scio/feeds/conf.py
@@ -40,6 +40,10 @@ def get_args() -> argparse.Namespace:
         help=f"sqlite db containing cached hashes. Default = {XDG_CACHE}/scio-feeds/cache.db",
     )
     parser.add_argument(
+        "--tlp",
+        help="Set TLP (RED, AMBER, GREEN, WHITE) on document upload",
+    )
+    parser.add_argument(
         "--scio",
         help="Upload to scio engine API url. "
         + "Set to empty value to not upload files.",

--- a/act/scio/feeds/upload.py
+++ b/act/scio/feeds/upload.py
@@ -15,27 +15,29 @@ def read_as_base64(obj: IO) -> Text:
     return encoded_bytes.decode("ascii")
 
 
-def to_scio_submit_post_data(obj: IO, filemap: Dict) -> Dict[Text, Text]:
+def to_scio_submit_post_data(obj: IO, filemap: Dict, tlp: Text) -> Dict[Text, Text]:
     """Take a file like object, and return a dictionary on the correct form for
     submitting to the SCIO API (https://github.com/mnemonic-no/act-scio-api)"""
 
     metadata = filemap.copy()
     metadata["content"] = read_as_base64(obj)
+    metadata["tlp"] = tlp
 
     assert "content" in metadata
     assert "filename" in metadata
     assert "uri" in metadata
+    assert "tlp" in metadata
 
     return metadata
 
 
-def upload(url: Text, filemap: Dict) -> None:
+def upload(url: Text, filemap: Dict, tlp: Text) -> None:
     """Upload a file to the Scio engine"""
 
     retry_codes = [429, None]
 
     with open(filemap["filename"], "rb") as file_h:
-        post_data = to_scio_submit_post_data(file_h, filemap)
+        post_data = to_scio_submit_post_data(file_h, filemap, tlp)
 
         # Disable all proxy settings from environment
         session = requests.Session()

--- a/act/scio/tlp.py
+++ b/act/scio/tlp.py
@@ -1,0 +1,9 @@
+from typing import Text, get_args
+
+from pydantic.typing import Literal
+
+TLP = Literal["RED", "AMBER", "GREEN", "WHITE"]
+
+
+def valid_tlp(tlp: Text) -> bool:
+    return tlp in get_args(TLP)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-scio",
-    version="0.0.41",
+    version="0.0.42",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",


### PR DESCRIPTION
`--tlp` option in feeds. With this option, the TLP will be stored with the document in the field "tlp".
