### PR TITLE
Documentation for scio cron and Elasticsearch type

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ sudo service start scio-tika-server
 sudo service start scio-analyze
 ```
 
+## scio-feed cron job
+
+To continously fetch new content from feeds, you can add scio-feed to cron like this (make sure the directory $HOME/logs exists):
+
+```
+# Fetch scio feeds every hour
+0 * * * * /usr/local/bin/scio-feeds >> $HOME/logs/scio-feed.log.$(date +\%s) 2>&1
+
+# Delete logs from scio-feeds older than 7 days
+0 * * * * find $HOME/logs/ -name 'scio-feed.log.*' -mmin +10080 -exec rm {} \;
+```
+
 ## Local development
 
 Use pip to install in [local development mode](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs). act-scio uses namespacing, so it is not compatible with using `setup.py install` or `setup.py develop`.

--- a/act/scio/config.py
+++ b/act/scio/config.py
@@ -24,8 +24,8 @@ import os
 from typing import Optional, Text
 
 import caep
-import elasticsearch
 import greenstalk
+from elasticsearch import Elasticsearch
 
 import act.scio.es
 
@@ -77,7 +77,7 @@ def beanstalk_client(
 
 def elasticsearch_client(
     args: argparse.Namespace,
-) -> Optional[elasticsearch.client.Elasticsearch]:
+) -> Optional[Elasticsearch]:
     """Return elasticsearch client if args.elasticsearch, otherwise, return None"""
     if args.elasticsearch:
         logging.info("Connection to elasticsearch")

--- a/act/scio/es.py
+++ b/act/scio/es.py
@@ -21,7 +21,6 @@ Elasticsearch utilities for scio
 from logging import debug
 from typing import Any, Dict, Iterator, List, Optional, Text, Tuple
 
-import elasticsearch
 import elasticsearch_dsl
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import A, Search
@@ -34,7 +33,7 @@ def es_client(
     username: Optional[Text] = None,
     password: Optional[Text] = None,
     timeout: int = 180,
-) -> elasticsearch.client.Elasticsearch:
+) -> Elasticsearch:
     """Elasticsearch client"""
 
     connection = {"host": host, "port": port}
@@ -54,7 +53,7 @@ def es_client(
 
 
 def query(
-    client: elasticsearch.client.Elasticsearch,
+    client: Elasticsearch,
     start: Text,
     end: Text,
     index: Text = "scio2",
@@ -116,7 +115,7 @@ def composite_aggs(
 
 
 def aggregation(
-    client: elasticsearch.client.Elasticsearch,
+    client: Elasticsearch,
     terms: List[Text],
     start: Text,
     end: Text,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-scio",
-    version="0.0.49",
+    version="0.0.50",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",
@@ -45,7 +45,7 @@ setup(
         "beautifulsoup4",
         "bs4",
         "caep",
-        "elasticsearch",
+        "elasticsearch>=8.0.0",
         "elasticsearch_dsl",
         "fastapi",
         "feedparser",


### PR DESCRIPTION
* Add documentation for running scio-feed in cron
* Fix Elasticsearch type (client is not exposed in elasticsearch version >= 8.0.0, and now verified that this works in both elasticsearch 7.x and 8.x)