### PR TITLE
store/owner

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         language: python
         entry: black
         types: [python]
-        additional_dependencies: [black==22.3.0]
+        additional_dependencies: [black==22.8.0]
 
   - repo: local
     hooks:
@@ -34,7 +34,7 @@ repos:
         language: python
         entry: mypy
         types: [python]
-        additional_dependencies: [mypy==0.950, pydantic]
+        additional_dependencies: [mypy==0.971, pydantic]
         args: ["--strict", "--install-types", "--non-interactive"]
 
   - repo: local

--- a/API.md
+++ b/API.md
@@ -10,14 +10,14 @@ Submit document for analysis.
 
 JSON document with the following fields:
 
-| Field      | Description                                                                              |
-|------------|------------------------------------------------------------------------------------------|
-| `content`  | Base 64 encoded document (required)                                                      |
-| `filename` | Filename of document (required)                                                          |
-| `uri`      | URI source of document (optional)                                                        |
-| `tlp`      | TLP of document (`RED`, `AMBER`, `GREEN` or `WHITE`) (optional)                          |
-| `owner`    | Identifier of document owner (stringl, optional)                                         |
-| `store`    | Specify whether document should be stored to elasticsearch/disk (optional, default=true) |
+| Field      | Description                                                                                    |
+|------------|------------------------------------------------------------------------------------------------|
+| `content`  | Base 64 encoded document (string, required)                                                    |
+| `filename` | Filename of document (string, required)                                                        |
+| `uri`      | URI source of document (string, optional, default=null)                                        |
+| `tlp`      | TLP of document (`RED`, `AMBER`, `GREEN` or `WHITE`) (string, optional, default=null)          |
+| `owner`    | Identifier of document owner (string, optional, default=null)                                  |
+| `store`    | Specify whether document should be stored to elasticsearch/disk (bool, optional, default=true) |
 
 #### Response:
 

--- a/API.md
+++ b/API.md
@@ -1,0 +1,68 @@
+# API Documentation
+
+SCIO API documentation.
+
+## `POST /submit`
+
+Submit document for analysis.
+
+TODO
+
+## `GET /indicators/{indicator_type}`
+
+Download indicators as text file.
+
+Allowed indicator types:
+- ipv4
+- ipv6
+- uri
+- email
+- fqdn
+- md5
+- sha1
+- sha256
+
+### Query parameters
+
+#### last
+
+maximum age of the document you want to get indicators (default=90d). The
+format should be either <NUM><TIME UNIT>, where TIME UNIT can be one of:
+
+- y (year)
+- M (month)
+- w (week)
+- d (day)
+- h (hour)
+- m (minute)
+- s (second)
+
+OR <EPOC> (only digits) where the EPOC is a unix timestamp in milliseconds.
+
+#### Response
+
+TODO
+
+#### Example
+
+```bash
+curl 'http://localhost:3000/indicators/sha256?last=1d'
+207132befb085f413480f8af9fdd690ddf5b9d21a9ea0d4a4e75f34f023ad95d
+2f11ca3dcc1d9400e141d8f3ee9a7a0d18e21908e825990f5c22119214fbb2f5
+34e7482d689429745dd3866caf5ddd5de52a179db7068f6b545ff51542abb76c
+3cb0d2cff9db85c8e816515ddc380ea73850846317b0bb73ea6145c026276948
+538d896cf066796d8546a587deea385db9e285f1a7ebf7dcddae22f8d61a2723
+6ee1e629494d7b5138386d98bd718b010ee774fe4a4c9d0e069525408bb7b1f7
+8bdd318996fb3a947d10042f85b6c6ed29547e1d6ebdc177d5d85fa26859e1ca
+8cb64b95931d435e01b835c05c2774b1f66399381b9fa0b3fb8ec07e18f836b0
+95bbd494cecc25a422fa35912ec2365f3200d5a18ea4bfad5566432eb0834f9f
+a896c2d16cadcdedd10390c3af3399361914db57bde1673e46180244e806a1d0
+```
+
+## `GET /download`
+
+TODO
+
+## `GET /download_json`
+
+TODO

--- a/API.md
+++ b/API.md
@@ -12,36 +12,24 @@ TODO
 
 Download indicators as text file.
 
-Allowed indicator types:
-- ipv4
-- ipv6
-- uri
-- email
-- fqdn
-- md5
-- sha1
-- sha256
+### URL Paramters
+
+| Parameter        | Description                                                                                              |
+|------------------|----------------------------------------------------------------------------------------------------------|
+| `indicator_type` | Indicator type to search for (`ipv4`, `ipv4`, `ipv6`, `uri`, `email`, `fqdn`, `md5`, `sha1` or `sha256`) |
 
 ### Query parameters
 
 #### last
 
-maximum age of the document you want to get indicators (default=90d). The
-format should be either <NUM><TIME UNIT>, where TIME UNIT can be one of:
 
-- y (year)
-- M (month)
-- w (week)
-- d (day)
-- h (hour)
-- m (minute)
-- s (second)
-
-OR <EPOC> (only digits) where the EPOC is a unix timestamp in milliseconds.
+| Parameter | Description                                                                                                                                                                                                                                                                                     |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `last`    | Maximum age of the indicator age (default=90d). The format should be either <NUM><TIME UNIT>, where TIME UNIT can be one of: `y` (year), `M` (month), `w` (week), `d` (day), `h` (hour), `m` (minute), `s` (second) or <EPOC> (only digits) where the EPOC is a unix timestamp in milliseconds. |
 
 #### Response
 
-TODO
+New line separated text of indicators.
 
 #### Example
 
@@ -59,10 +47,35 @@ curl 'http://localhost:3000/indicators/sha256?last=1d'
 a896c2d16cadcdedd10390c3af3399361914db57bde1673e46180244e806a1d0
 ```
 
-## `GET /download`
+## `GET /download/{id}`
 
-TODO
+Download document as file.
 
-## `GET /download_json`
+### URL Paramters
 
-TODO
+| Field      | Description             |
+|------------|-------------------------|
+| `id`       | SHA 256 sum of document |
+
+
+## `GET /download_json/{id}`
+
+Download document in in JSON response object.
+
+### URL Paramters
+
+| Field      | Description             |
+|------------|-------------------------|
+| `id`       | SHA 256 sum of document |
+
+
+#### Response:
+
+JSON document with the following fields:
+
+| Field      | Description                         |
+|------------|-------------------------------------|
+| `error`    | Error descripton (null if no Error) |
+| `bytes`    | Document size in bytes              |
+| `content`  | Base 64 encoded document content    |
+| `encoding` | `base64`                            |

--- a/API.md
+++ b/API.md
@@ -51,7 +51,7 @@ Download indicators as text file.
 
 | Parameter | Description                                                                                                                                                                                                                                                                                     |
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `last`    | Maximum age of the indicator age (default=90d). The format should be either <NUM><TIME UNIT>, where TIME UNIT can be `y` (year), `M` (month), `w` (week), `d` (day), `h` (hour), `m` (minute), `s` (second) or <EPOC> (only digits) where the EPOC is a unix timestamp in milliseconds. |
+| `last`    | Maximum age of the indicator (default=90d). The format should be either <NUM><TIME UNIT>, where TIME UNIT can be `y` (year), `M` (month), `w` (week), `d` (day), `h` (hour), `m` (minute), `s` (second) or <EPOC> (only digits) where the EPOC is a unix timestamp in milliseconds. |
 
 #### Response
 

--- a/API.md
+++ b/API.md
@@ -10,29 +10,29 @@ Submit document for analysis.
 
 JSON document with the following fields:
 
-| Field      | Description                                                                                    |
-|------------|------------------------------------------------------------------------------------------------|
-| `content`  | Base 64 encoded document (string, required)                                                    |
-| `filename` | Filename of document (string, required)                                                        |
-| `uri`      | URI source of document (string, optional, default=null)                                        |
-| `tlp`      | TLP of document (`RED`, `AMBER`, `GREEN` or `WHITE`) (string, optional, default=null)          |
-| `owner`    | Identifier of document owner (string, optional, default=null)                                  |
-| `store`    | Specify whether document should be stored to elasticsearch/disk (bool, optional, default=true) |
+| Field      | Description                                                     | Required | Type    | Default |
+|------------|-----------------------------------------------------------------|----------|---------|---------|
+| `content`  | Base 64 encoded document                                        | `yes`    | string  | n/a     |
+| `filename` | Filename of document                                            | `yes`    | string  | n/a     |
+| `uri`      | URI source of document                                          | `no`     | string  | null    |
+| `tlp`      | TLP of document (`RED`, `AMBER`, `GREEN` or `WHITE`)            | `no`     | string  | null    |
+| `owner`    | Identifier of document owner                                    | `no`     | string  | null    |
+| `store`    | Specify whether document should be stored to elasticsearch/disk | `no`     | boolean | true    |
 
 #### Response:
 
 JSON document with the following fields:
 
-| Field       | Description                                      |
-|-------------|--------------------------------------------------|
-| `filename`  | Fielname as specified in the request             |
-| `uri`       | URI source from request                          |
-| `tlp`       | TLP from request                                 |
-| `owner`     | Owner from request                               |
-| `store`     | Store from request                               |
-| `hexdigest` | SHA256 of uploaded document                      |
-| `count`     | Bytes of uploaded document (after base64 decode) |
-| `error`     | Error description (null if no error)             |
+| Field       | Description                                      | Type    |
+|-------------|--------------------------------------------------|---------|
+| `filename`  | Filename as specified in the request             | string  |
+| `uri`       | URI source from request                          | string  |
+| `tlp`       | TLP from request                                 | string  |
+| `owner`     | Owner from request                               | boolean |
+| `store`     | Store from request                               | string  |
+| `hexdigest` | SHA256 of uploaded document                      | string  |
+| `count`     | Bytes of uploaded document (after base64 decode) | int     |
+| `error`     | Error description (null if no error)             | string  |
 
 ## `GET /indicators/{indicator_type}`
 

--- a/API.md
+++ b/API.md
@@ -6,7 +6,33 @@ SCIO API documentation.
 
 Submit document for analysis.
 
-TODO
+### POST body
+
+JSON document with the following fields:
+
+| Field      | Description                                                                              |
+|------------|------------------------------------------------------------------------------------------|
+| `content`  | Base 64 encoded document (required)                                                      |
+| `filename` | Filename of document (required)                                                          |
+| `uri`      | URI source of document (optional)                                                        |
+| `tlp`      | TLP of document (`RED`, `AMBER`, `GREEN` or `WHITE`) (optional)                          |
+| `owner`    | Identifier of document owner (stringl, optional)                                         |
+| `store`    | Specify whether document should be stored to elasticsearch/disk (optional, default=true) |
+
+#### Response:
+
+JSON document with the following fields:
+
+| Field       | Description                                      |
+|-------------|--------------------------------------------------|
+| `filename`  | Fielname as specified in the request             |
+| `uri`       | URI source from request                          |
+| `tlp`       | TLP from request                                 |
+| `owner`     | Owner from request                               |
+| `store`     | Store from request                               |
+| `hexdigest` | SHA256 of uploaded document                      |
+| `count`     | Bytes of uploaded document (after base64 decode) |
+| `error`     | Error description (null if no error)             |
 
 ## `GET /indicators/{indicator_type}`
 
@@ -25,7 +51,7 @@ Download indicators as text file.
 
 | Parameter | Description                                                                                                                                                                                                                                                                                     |
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `last`    | Maximum age of the indicator age (default=90d). The format should be either <NUM><TIME UNIT>, where TIME UNIT can be one of: `y` (year), `M` (month), `w` (week), `d` (day), `h` (hour), `m` (minute), `s` (second) or <EPOC> (only digits) where the EPOC is a unix timestamp in milliseconds. |
+| `last`    | Maximum age of the indicator age (default=90d). The format should be either <NUM><TIME UNIT>, where TIME UNIT can be `y` (year), `M` (month), `w` (week), `d` (day), `h` (hour), `m` (minute), `s` (second) or <EPOC> (only digits) where the EPOC is a unix timestamp in milliseconds. |
 
 #### Response
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The result is sent to the Scio Analyzer that extracts information using a combin
 
 ### 0.0.42
 
-SCIO now supports setting TLP on data upload, to annotatet documents with `tlp` tag. Documents downloaded by feeds will have a default TLP white, but this can be changed in the config for feeds.
+SCIO now supports setting TLP on data upload, to annotate documents with `tlp` tag. Documents downloaded by feeds will have a default TLP white, but this can be changed in the config for feeds.
 
 ## Source code
 
@@ -59,6 +59,8 @@ scio-api
 
 This will setup the API on 127.0.0.1:3000. Use `--port <PORT> and --host <IP>` to listen on another port and/or another interface.
 
+For documentation of the API endpoint see [API.md](API.md).
+
 ## Configuration
 
 You can create a default configuration using this command (should be run as the user running scio):
@@ -95,6 +97,19 @@ You can also read directly from stdin like this:
 
 ```bash
 echo "The companies in the Bus; Finanical, Aviation and Automobile industry are large." | scio-analyze --beanstalk=
+```
+
+### Scio Submit
+
+Submit document (from file or URI) to `scio_api`.
+
+Example:
+
+```bash
+scio-submit \
+   --uri https://www2.fireeye.com/rs/848-DID-242/images/rpt-apt29-hammertoss.pdf \
+   --scio-baseuri http://localhost:3000/submit \
+   --tlp white
 ```
 
 ## Running as a service

--- a/act/scio/alias.py
+++ b/act/scio/alias.py
@@ -147,7 +147,7 @@ def fetch_json(
     }
 
     if not verify_https:
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)  # type: ignore
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # Unable to infer type
     req = requests.get(url, **options)  # type: ignore

--- a/act/scio/api.py
+++ b/act/scio/api.py
@@ -76,6 +76,12 @@ def max_current_jobs_ready(client: greenstalk.Client, tubes: List[Text]) -> int:
     return max_jobs
 
 
+def create_path_if_not_exists(path: Path) -> None:
+    if not path.is_dir():
+        path.mkdir()
+        logging.info("Created directory: %s", path)
+
+
 # parse_args() is executed the first time and later the cached result
 # is used. In this way, we use to configure settings in API endpoints
 @lru_cache()
@@ -114,10 +120,8 @@ def parse_args() -> argparse.Namespace:
 
     nostore_path = args.document_path / "NOSTORE"
 
-    for path in (args.document_path, nostore_path):
-        if not path.is_dir():
-            path.mkdir()
-            logging.info("Created directory: %s", path)
+    create_path_if_not_exists(args.document_path)
+    create_path_if_not_exists(nostore_path)
 
     args.beanstalk_client = act.scio.config.beanstalk_client(args, use="scio_doc")
     args.elasticsearch_client = act.scio.config.elasticsearch_client(args)

--- a/act/scio/api.py
+++ b/act/scio/api.py
@@ -25,7 +25,8 @@ import logging
 import os
 import re
 from functools import lru_cache
-from typing import Dict, List, Optional, Text, Union, cast
+from pathlib import Path, PurePath
+from typing import Dict, List, Text, Union, cast
 
 import caep
 import elasticsearch
@@ -33,13 +34,13 @@ import greenstalk
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi.responses import FileResponse, PlainTextResponse
-from pydantic import BaseModel, ConstrainedStr, StrictInt, StrictStr
+from pydantic import ConstrainedStr
 
 import act.scio.config
 import act.scio.es
-from act.scio import tlp
+from act.scio.models import Document, LookupResponse, SubmitResponse
 
-XDG_CACHE = os.path.expanduser(os.environ.get("XDG_CACHE_HOME", "~/.cache"))
+XDG_CACHE = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
 
 app = FastAPI()
 
@@ -75,33 +76,6 @@ def max_current_jobs_ready(client: greenstalk.Client, tubes: List[Text]) -> int:
     return max_jobs
 
 
-class Document(BaseModel):
-    """Document model"""
-
-    content: StrictStr
-    filename: StrictStr
-    uri: Optional[StrictStr]
-    tlp: Optional[tlp.TLP]
-
-
-class LookupResponse(BaseModel):
-    """Response model for document search"""
-
-    filename: StrictStr
-    content_type: StrictStr
-
-
-class SubmitResponse(BaseModel):
-    """Response model for document submit"""
-
-    filename: StrictStr
-    hexdigest: StrictStr
-    count: StrictInt
-    uri: Optional[StrictStr]
-    tlp: Optional[tlp.TLP]
-    error: Optional[StrictStr]
-
-
 # parse_args() is executed the first time and later the cached result
 # is used. In this way, we use to configure settings in API endpoints
 @lru_cache()
@@ -126,6 +100,7 @@ def parse_args() -> argparse.Namespace:
     arg_parser.add_argument(
         "--document-path",
         default=caep.get_cache_dir("scio/documents"),
+        type=Path,
         help=f"Storage path for documents = {XDG_CACHE}/scio/documents",
     )
     arg_parser.add_argument(
@@ -137,9 +112,12 @@ def parse_args() -> argparse.Namespace:
 
     args = caep.config.handle_args(arg_parser, "scio/etc", "scio.ini", "api")
 
-    if not os.path.isdir(args.document_path):
-        os.makedirs(args.document_path)
-        logging.info("Created directory: %s", args.document_path)
+    nostore_path = args.document_path / "NOSTORE"
+
+    for path in (args.document_path, nostore_path):
+        if not path.is_dir():
+            path.mkdir()
+            logging.info("Created directory: %s", path)
 
     args.beanstalk_client = act.scio.config.beanstalk_client(args, use="scio_doc")
     args.elasticsearch_client = act.scio.config.elasticsearch_client(args)
@@ -183,18 +161,22 @@ async def submit(
             status_code=429, detail="To many jobs in queue, try again later"
         )
 
-    filename = os.path.join(args.document_path, os.path.basename(doc.filename))
+    path = args.document_path if doc.store else args.document_path / "NOSTORE"
+
+    filename = path / PurePath(doc.filename).name
     content: bytes = base64.b64decode(doc.content)
     with open(filename, "bw") as f:
         f.write(content)
 
     response = SubmitResponse(
-        filename=filename,
+        filename=str(filename),
         hexdigest=hashlib.sha256(content).hexdigest(),
         count=len(content),
         tlp=doc.tlp,
         error=None,
         uri=doc.uri,
+        store=doc.store,
+        owner=doc.owner,
     )
 
     args.beanstalk_client.put(response.json().encode("utf8"))
@@ -221,7 +203,7 @@ def indicators(
 
     You can also specify the maximum age of the document you want to
     get indicators from with the `last` argument (default=90d). The
-    format should be either be <NUM><TIME UNIT>, where TIME UNIT can be one of:
+    format should be either <NUM><TIME UNIT>, where TIME UNIT can be one of:
 
     y (year)
     M (month)
@@ -264,12 +246,12 @@ def download(
     """Download document as original content"""
     res = document_lookup(id, args.elasticsearch_client)
 
-    if not os.path.isfile(res.filename):
+    if not Path(res.filename).is_file():
         return Response(content="File not found", media_type="application/text")
 
     return FileResponse(
         res.filename,
-        filename=os.path.basename(res.filename),
+        filename=PurePath(res.filename).name,
         media_type=res.content_type,
     )
 
@@ -282,7 +264,7 @@ def download_json(
     """Download document base64 decoded in json struct"""
     res = document_lookup(id, args.elasticsearch_client)
 
-    if not os.path.isfile(res.filename):
+    if not Path(res.filename).is_file():
         return {
             "error": "File not found",
             "bytes": 0,

--- a/act/scio/feeds/download.py
+++ b/act/scio/feeds/download.py
@@ -122,7 +122,7 @@ def proxies(proxy_string: Optional[Text]) -> Optional[Dict[Text, Text]]:
 def default_headers() -> Dict[Text, Text]:
     """Return default headers with a custom user agent"""
 
-    headers = requests.utils.default_headers()  # type: ignore
+    headers = requests.utils.default_headers()
     headers.update(
         {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "

--- a/act/scio/feeds/feeds.py
+++ b/act/scio/feeds/feeds.py
@@ -33,7 +33,7 @@ from act.scio.feeds import cache, conf, download, upload
 from act.scio.logsetup import setup_logging
 from act.scio.tlp import valid_tlp
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)  # type: ignore
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 def sha256_of_file(filename: Text) -> Text:

--- a/act/scio/models.py
+++ b/act/scio/models.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+from pydantic import BaseModel, StrictInt, StrictStr
+
+from act.scio.tlp import TLP
+
+
+class BaseDocument(BaseModel):
+    """Document model"""
+
+    filename: StrictStr
+    uri: Optional[StrictStr]
+    tlp: Optional[TLP]
+    owner: Optional[StrictStr]
+    store: bool = True
+
+
+class Document(BaseDocument):
+    """Document model"""
+
+    content: StrictStr
+
+
+class LookupResponse(BaseModel):
+    """Response model for document search"""
+
+    filename: StrictStr
+    content_type: StrictStr
+
+
+class SubmitResponse(BaseDocument):
+    """Response model for document submit"""
+
+    hexdigest: StrictStr
+    count: StrictInt
+    error: Optional[StrictStr]

--- a/act/scio/models.py
+++ b/act/scio/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, StrictInt, StrictStr
 from act.scio.tlp import TLP
 
 
-class BaseDocument(BaseModel):
+class ScioBaseDocument(BaseModel):
     """Document model"""
 
     filename: StrictStr
@@ -15,7 +15,7 @@ class BaseDocument(BaseModel):
     store: bool = True
 
 
-class Document(BaseDocument):
+class Document(ScioBaseDocument):
     """Document model"""
 
     content: StrictStr
@@ -28,7 +28,7 @@ class LookupResponse(BaseModel):
     content_type: StrictStr
 
 
-class SubmitResponse(BaseDocument):
+class SubmitResponse(ScioBaseDocument):
     """Response model for document submit"""
 
     hexdigest: StrictStr

--- a/act/scio/submit.py
+++ b/act/scio/submit.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import argparse
+import base64
+import hashlib
+import os.path
+import sys
+from typing import Any, Dict, Optional, Text, Tuple
+
+import requests
+
+from act.scio import tlp
+from act.scio.models import Document
+
+"Submit content of URI / File to SCIO"
+
+
+def fatal(message: Text, exit_code: int = 1) -> None:
+    "Print error message and abort"
+    sys.stderr.write(message + "\n")
+    sys.exit(exit_code)
+
+
+VALID_TLP = ", ".join(tlp.TLP_ALLOWED_VALUES)
+
+
+def parseargs(description: Text) -> argparse.Namespace:
+    """Parse arguments"""
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument("--http-timeout", type=int, default=120, help="Timeout")
+    parser.add_argument("--proxy-string", help="Proxy to use for external queries")
+    parser.add_argument("--scio-baseuri", required=True, help="SCIO API URI")
+    parser.add_argument("--http-user", help="SCIO HTTP Basic Auth user")
+    parser.add_argument("--http-password", help="SCIO HTTP Basic Auth password")
+    parser.add_argument("--uri", help="Download content from URI and submit content")
+    parser.add_argument("--filename", help="Submit file")
+    parser.add_argument(
+        "--nostore",
+        action="store_true",
+        help="Do not store document to elasticsearch/disk",
+    )
+    parser.add_argument("--tlp", default="AMBER", help=f"tlp ({VALID_TLP})")
+    parser.add_argument("--owner", help="Document owner (identifier)")
+    args = parser.parse_args()
+
+    if not (args.uri or args.filename):
+        fatal("Specify either --uri or --filename")
+
+    args.tlp = args.tlp.upper()
+
+    if not tlp.valid_tlp(args.tlp):
+        fatal(f"Invalid TLP: {args.tlp}. Must be one of: {VALID_TLP}")
+
+    return args
+
+
+def get_uri(
+    uri: Text, proxies: Optional[Dict[Text, Any]], timeout: Optional[int] = 30
+) -> bytes:
+    "Return content from URI"
+    req = requests.get(uri, proxies=proxies, timeout=timeout)
+
+    if not req.status_code == 200:
+        fatal("Unable to get {}. Status code={}".format(uri, req.status_code))
+
+    return req.content
+
+
+def get_file(filename: Text) -> bytes:
+    "Return content from file"
+    with open(filename, "rb") as f:
+        return f.read()
+
+
+def scio_submit(
+    submit_uri: Text,
+    content: bytes,
+    filename: Text,
+    owner: Optional[Text],
+    auth: Optional[Tuple[Text, Text]],
+    uri: Optional[Text],
+    tlp: tlp.TLP = "AMBER",
+    store: bool = False,
+) -> None:
+    "Submit content with specified filename to SCIO"
+
+    sha256 = hashlib.sha256(content).hexdigest()
+
+    # If filename is not specified, use sha256
+    if not filename:
+        filename = sha256
+
+    document = Document(
+        content=base64.b64encode(content).decode("utf8"),
+        tlp=tlp,
+        filename=filename,
+        owner=owner,
+        store=store,
+        uri=uri,
+    )
+
+    req = requests.post(submit_uri, json=document.dict(), auth=auth)
+
+    if not req.status_code == 200:
+        fatal(f"Unable to submit {filename} to scio ({submit_uri}), error={req.text}")
+
+    print(f"Submitted {sha256}: {req.text}")
+
+
+def main() -> None:
+    "main function"
+
+    args = parseargs("SCIO submit from URI/File")
+    auth = (args.http_user, args.http_password) if args.http_user else None
+
+    proxies = (
+        {"http": args.proxy_string, "https": args.proxy_string}
+        if args.proxy_string
+        else None
+    )
+
+    if args.uri:
+        content = get_uri(args.uri, proxies=proxies, timeout=args.http_timeout)
+        # Use basename from URI as filename
+        filename = os.path.basename(args.uri)
+
+    elif args.filename:
+        content = get_file(args.filename)
+        # Use basename from file
+        filename = os.path.basename(args.filename)
+
+    try:
+        scio_submit(
+            args.scio_baseuri,
+            content,
+            filename,
+            args.owner,
+            auth,
+            args.uri if args.uri else None,
+            args.tlp,
+            not args.nostore,
+        )
+    except requests.exceptions.ConnectionError as e:
+        fatal(f"Unable to connect to {args.scio_baseuri}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,7 +64,7 @@ services:
 
   scio-elasticsearch:
     <<: *common
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.1
     environment:
       - node.name=elasticsearch
       - cluster.name=scio
@@ -73,6 +73,7 @@ services:
       - xpack.security.enabled=false
       - ES_SETTING_INGEST_GEOIP_DOWNLOADER_ENABLED=false
       - "ES_JAVA_OPTS=-Xms2048m -Xmx2048m"
+      - logger.level=ERROR
     ulimits:
       memlock:
         soft: -1
@@ -81,12 +82,16 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
   scio-kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.2
+    <<: *common
+    image: docker.elastic.co/kibana/kibana:8.4.1
     environment:
       SERVER_NAME: localhost
       ELASTICSEARCH_HOSTS: '["http://scio-elasticsearch:9200"]'
+      LOGGING_ROOT_LEVEL: "error"
     ports:
       - 127.0.0.1:5601:5601
+    depends_on:
+      - scio-elasticsearch
 
 volumes:
   elasticsearch-data:

--- a/docker/scio/Dockerfile
+++ b/docker/scio/Dockerfile
@@ -47,3 +47,5 @@ RUN cd scio && \
     --trusted-host pypi.org \
     --trusted-host pypi.python.org \
     --trusted-host files.pythonhosted.org dist/*gz
+
+RUN scio-config user

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-scio",
-    version="0.0.51",
+    version="0.0.52",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",
     description="ACT SCIO",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    license="MIT",
+    license="ISC",
     keywords="ACT, mnemonic",
     entry_points={
         "console_scripts": [
@@ -29,6 +29,7 @@ setup(
             "scio-tika-server = act.scio.tika_engine:main",
             "scio-nltk-download= act.scio.nltk_download:main",
             "scio-upload = act.scio.upload:main",
+            "scio-submit= act.scio.submit:main",
         ]
     },
     # Include ini-file(s) from act/workers/etc


### PR DESCRIPTION
- New feature:  store  (default=True) which tells whether the documents will be stored to disk/elasticsearch
- New feature:  owner: Optional Identifier (string) to set owner of document
- New script: scio-submit - submit documents fetched from file or uri to SCIO
- Switch from os.path to pathlib in api.py
- Refactor models and move to separate file
- Docker update: upgrade elasticsearch/kibana, fix kibana network, set debug level to ERROR, fix kibana network
- Document API endpoints
- mypy/pylint updates