### PR TITLE
Add support for new Microsoft threat actor naming

### DIFF
--- a/act/scio/aliasregex.py
+++ b/act/scio/aliasregex.py
@@ -84,6 +84,7 @@ def normalize(
     upper: bool = False,
     capitalize: bool = False,
     uppercase_abbr: Optional[List[Text]] = None,
+    allow_non_alphanumeric: Optional[Text] = None,
 ) -> str:
     """
 
@@ -96,6 +97,8 @@ def normalize(
     upper (bool): uppercase
     capitalize (bool): uppercase all first characters in words
     uppercase_abbr (list[str]): list of abbrevations to uppercase
+    allow_non_alphanumeric (str): regular expression that will be excluded from
+                                  removal of non_alphanumeric characters
 
     The transformation in ran in the same order as the arguments are specified,
     so you can use lower=True and capitalize=True to transform sOmeThing -> Something
@@ -112,7 +115,9 @@ def normalize(
         # Replace "winntiGroup" with "winnti group"
         name = re.sub(r"([a-z])([A-Z])", r"\1 \2", name)
 
-    if remove_non_alphanumeric:
+    if remove_non_alphanumeric and not (
+        allow_non_alphanumeric and re.search(allow_non_alphanumeric, name)
+    ):
         # Replace "APT-27" with "APT 27"
         name = re.sub(r"[^a-zA-Z0-9 ]+", " ", name, 0)
 

--- a/act/scio/etc/plugins/threatactor_pattern.ini
+++ b/act/scio/etc/plugins/threatactor_pattern.ini
@@ -2,8 +2,11 @@
 object_type = threatActor
 alias = ta_aliases.cfg
 regexfromalias = True
+allow_non_alphanumeric =  ^(?i)storm-[0-9]{4}
 uppercase_abbr=APT|BRONZE|IRON|GOLD|UNC
 regexmanual =
     \b([a-zA-Z]{4,}\s?[-_. ](?:dragon|duke|falcon|cedar|viper|panda|bear|jackal|spider|chollima|kitten|tiger))\b
+    \b([a-zA-Z]{4,}\s+(?:Typhoon|Sandstorm|Rain|Sleet|Blizzard|Hail|Dust|Cyclone|Tempest|Tsunami|Flood))\b
     \b((?:BRONZE|IRON|GOLD)(?:\s+|[-_.]+)[A-Z]{3,})\b
     \b(UNC[0-9]{4})\b
+    \b(Storm-[0-9]{4})\b

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-scio",
-    version="0.0.53",
+    version="0.0.54",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",

--- a/tests/test_threatactor_pattern.py
+++ b/tests/test_threatactor_pattern.py
@@ -12,7 +12,17 @@ async def test_threatactor_pattern() -> None:
 
     nlpdata = addict.Dict()
 
-    nlpdata.content = """Lorem Ipsum Dirty Panda, APT1 APT-2, Apt 35, APT_46, UNC2354"""
+    nlpdata.content = """
+
+    Lorem Ipsum Dirty Panda, APT1 APT-2, Apt 35, APT_46, UNC2354
+
+    The threat actors aqua blizzard was previous known as ACTINIUM
+
+    Pumpkin Sandstorm was known as DEV-0146
+
+    DEV-0257 is know renamed to Storm-0257.
+
+    """
 
     plugin = threatactor_pattern.Plugin()
     plugin.configdir = os.path.join(
@@ -26,3 +36,6 @@ async def test_threatactor_pattern() -> None:
     assert "APT 35" in res.result.ThreatActors
     assert "APT 46" in res.result.ThreatActors
     assert "UNC 2354" in res.result.ThreatActors
+    assert "Aqua Blizzard" in res.result.ThreatActors
+    assert "Pumpkin Sandstorm" in res.result.ThreatActors
+    assert "Storm-0257" in res.result.ThreatActors


### PR DESCRIPTION
Required update to the normalize function to make sure storm-<digits> is not replace with "storm <digits>".