### PR TITLE
Support tika 2.x and update docker config

### DIFF
--- a/act/scio/analyze.py
+++ b/act/scio/analyze.py
@@ -76,7 +76,6 @@ def remove_non_iso_dates(
     filtered = {}
 
     for key, value in metadata.items():
-
         if key in isodate_fields:
             if not isinstance(value, str):
                 logging.warning("date value is not string %s:%s", key, value)
@@ -134,7 +133,7 @@ async def analyze(
     # make sure we have a Creation-Date field even though the
     # document did not contain one. When missing, use current analyzed time.
     nlpdata["Creation-Date"] = nlpdata.get("metadata", {}).get(
-        "Creation-Date", nlpdata["Analyzed-Date"]
+        "dcterms:created", nlpdata["Analyzed-Date"]
     )
 
     staged = []  # for plugins with dependencies
@@ -245,7 +244,6 @@ async def async_main() -> None:
                 logging.error("Unable to post result data to webdump: %s", r.text)
 
         if elasticsearch_client and store:
-
             if not hexdigest:
                 logging.error("Missing hexdigest, skipping elasticsearch storage")
             else:

--- a/act/scio/api.py
+++ b/act/scio/api.py
@@ -26,7 +26,7 @@ import os
 import re
 from functools import lru_cache
 from pathlib import Path, PurePath
-from typing import Dict, List, Text, Union, cast
+from typing import Dict, List, Text, cast, Any
 
 import caep
 import elasticsearch
@@ -264,7 +264,7 @@ def download(
 def download_json(
     id: SHA256Regex,
     args: argparse.Namespace = Depends(parse_args),
-) -> Union[Response, Dict[Text, Text]]:
+) -> Dict[Text, Any]:
     """Download document base64 decoded in json struct"""
     res = document_lookup(id, args.elasticsearch_client)
 

--- a/act/scio/tika_engine.py
+++ b/act/scio/tika_engine.py
@@ -31,7 +31,6 @@ class Server:
     Apache Tika for text extraction and den sending it to Scio for text analyzis."""
 
     def __init__(self, beanstalk_host: Text = "127.0.0.1", beanstalk_port: int = 11300):
-
         self.client: Optional[greenstalk.Client] = None
         self.connect(beanstalk_host, beanstalk_port)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,7 @@ docker-compose build
 Build With proxy:
 
 ```bash
-docker-compose build --build-arg http_proxy=http://<PROXY>:<PORT> --build-arg https_proxy http://<PROXY>:<PORT>
+docker-compose build --build-arg http_proxy=http://<PROXY>:<PORT> --build-arg=https_proxy http://<PROXY>:<PORT>
 ```
 
 ## Run

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,18 +36,15 @@ x-meta-scio: &scio
 
 services:
   scio-tika-server:
-    <<: *common
-    <<: *scio
+    <<: [*scio, *common]
     command: scio-tika-server
 
   scio-analyze:
-    <<: *common
-    <<: *scio
+    <<: [*scio, *common]
     command: scio-analyze
 
   scio-api:
-    <<: *common
-    <<: *scio
+    <<: [*scio, *common]
     command: scio-api --host 0.0.0.0
     ports:
       - 127.0.0.1:3000:3000
@@ -64,7 +61,7 @@ services:
 
   scio-elasticsearch:
     <<: *common
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0
     environment:
       - node.name=elasticsearch
       - cluster.name=scio
@@ -83,11 +80,12 @@ services:
 
   scio-kibana:
     <<: *common
-    image: docker.elastic.co/kibana/kibana:8.4.1
+    image: docker.elastic.co/kibana/kibana:8.7.0
     environment:
       SERVER_NAME: localhost
       ELASTICSEARCH_HOSTS: '["http://scio-elasticsearch:9200"]'
       LOGGING_ROOT_LEVEL: "error"
+      telemetry.optIn: false
     ports:
       - 127.0.0.1:5601:5601
     depends_on:

--- a/docker/scio/Dockerfile
+++ b/docker/scio/Dockerfile
@@ -5,11 +5,11 @@ RUN apt -y install openjdk-11-jdk-headless curl inetutils-ping telnet python3 py
 
 # Download tika jar+md5 that will be used by tika-server
 RUN mkdir /opt/tika
-ENV TIKA_VERSION=1.28.1
-RUN curl --insecure -o /opt/tika/tika-server.jar \
-    https://repo1.maven.org/maven2/org/apache/tika/tika-server/${TIKA_VERSION}/tika-server-${TIKA_VERSION}.jar
-RUN curl --insecure -o /opt/tika/tika-server.jar.md5 \
-    https://repo1.maven.org/maven2/org/apache/tika/tika-server/${TIKA_VERSION}/tika-server-${TIKA_VERSION}.jar.md5
+ENV TIKA_VERSION=2.7.0
+RUN curl -L --insecure -o /opt/tika/tika-server.jar \
+    https://dlcdn.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar
+RUN curl -L --insecure -o /opt/tika/tika-server.jar.md5 \
+    https://dlcdn.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar.md5
 RUN chmod -R go+rX /opt/tika
 
 RUN useradd -ms /bin/bash scio
@@ -37,7 +37,7 @@ COPY /etc scio/etc
 COPY /setup.py scio/setup.py
 COPY /README.md scio/README.md
 
-RUN mkdir -p /home/scio/.cache/scio
+RUN mkdir -p .cache/scio .config
 RUN chown scio:scio /home/scio/.cache/scio
 
 RUN cd scio && \

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-scio",
-    version="0.0.54",
+    version="0.0.55",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",


### PR DESCRIPTION
- Test/support tika 2.x (tested in docker with Tika 2.7.0)
- Bump elasticsearch/kibana version in docker
- Support user-agent in URI download in scio submit
- Fix docker-compose inheritance syntax. Newer version only supports one inheritance key, so we need to use a list instead of multiple `<<`